### PR TITLE
Remove '/job' from url

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -26,5 +26,5 @@ jobs:
         uses: nationalarchives/dr2-github-actions/.github/actions/slack-send@main
         if: failure()
         with:
-          message: ":warning: E2E tests have failed. <https://github.com/nationalarchives/dr2-e2e-tests/actions/runs/${{ github.run_id }}/job/${{ github.run_number }}|View the workflow run>"
+          message: ":warning: E2E tests have failed. <https://github.com/nationalarchives/dr2-e2e-tests/actions/runs/${{ github.run_id }}|View the workflow run>"
           slack-url: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
I don't think you can get the job id; it seems to be dynamically generated.